### PR TITLE
Serve Index File Instead of Directory Listing if Available

### DIFF
--- a/source/hunt/http/server/HttpServer.d
+++ b/source/hunt/http/server/HttpServer.d
@@ -548,12 +548,18 @@ class HttpServer : AbstractLifecycle {
         alias addNotFoundRoute = setDefaultRequest;
 
         Builder resource(string path, string localPath, bool canList = true,
-                string groupName=null, RouteGroupType groupType = RouteGroupType.Host) {
+                string groupName=null, RouteGroupType groupType = RouteGroupType.Host, 
+                string indexFile = "index.html") {
             DefaultResourceHandler handler = new DefaultResourceHandler(amendingPath(path), localPath);
             handler.isListingEnabled = canList;
             handler.cacheTime = _resourceCacheTime;
+            handler.indexFile = indexFile;
             
             return resource(path, handler, groupName, groupType);
+        }
+
+        Builder resource(string path, string localPath, string indexFile) {
+            return resource(path, localPath, true, null, RouteGroupType.Host, indexFile);
         }
 
         private static string amendingPath(string path) {


### PR DESCRIPTION
This will serve a index file (for example `index.html`) instead of a directory listing, if that index file is available. That index file can be customized, for example:

```d
auto server = HttpServer.builder()
      .setListener(8080)
      .resource("/", "./resources", "custom_index.html")
```

This behaviour can also be completely disabled again by passing `null` to `indexFile`:

```d
auto server = HttpServer.builder()
      .setListener(8080)
      .resource("/", "./resources", null)
```